### PR TITLE
Fixes markdown link formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Have any questions or concerns? Did I forget an element or selector? Does someth
 - Blockquotes
 - Update screenshots
 - Jekyll theme
-- (Code/kbd/blocks)[https://github.com/kognise/water.css/issues/1]
+- [Code/kbd/blocks](https://github.com/kognise/water.css/issues/1)
 - Nicer buttons?
 
 Feel free to help! :P


### PR DESCRIPTION
Tiny change, but a link in your README.md file is not marked-up properly