### PR TITLE
Change chalk into devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "devDependencies": {
     "autoprefixer": "^9.5.1",
     "browser-sync": "^2.26.3",
+    "chalk": "^2.4.2",
     "cssnano": "^4.1.10",
     "gulp": "^4.0.0",
     "gulp-bytediff": "^1.0.0",
@@ -35,8 +36,5 @@
   },
   "browserslist": [
     "defaults AND not android 4.4.3"
-  ],
-  "dependencies": {
-    "chalk": "^2.4.2"
-  }
+  ]
 }


### PR DESCRIPTION
Hi.
I saw a plan to publish to npm.(#41) It's great plan! !

I saw package.json.
I think that `chalk` should be included in `devDependencies`, not `dependencies`.
Because `chalk` is not a part of water.css, it is a library for development.
When installing with npm command, `chalk` will also be installed in node_modules.