### PR TITLE
Changed switch button function for IE11 compatibility

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,4 +1,4 @@
-document.getElementById('switch').addEventListener('click', () => {
+document.getElementById('switch').addEventListener('click', function() {
   const stylesheet = document.getElementById('stylesheet')
   const ph = document.getElementById('ph')
   if (stylesheet.getAttribute('href') === 'dist/dark.css') {


### PR DESCRIPTION
Fixes [#61] Switch Theme button doesn't work in IE11 

Arrow function was not supported in IE11. Changed to anonymous function and resolved issue.