### PR TITLE
Fix high specificity for input display property

### DIFF
--- a/src/parts/_forms.scss
+++ b/src/parts/_forms.scss
@@ -5,9 +5,14 @@ input[type='checkbox'] {
   cursor: pointer;
 }
 
-input:not([type='checkbox']):not([type='radio']),
+input,
 select {
   display: block;
+}
+
+[type='checkbox'],
+[type='radio'] {
+  display: initial;
 }
 
 input, select, button, textarea {


### PR DESCRIPTION
This will reduce input selector specificity for display property to prevent overriding user written css. fix [#78](https://github.com/kognise/water.css/issues/78).