### PR TITLE
Fix switch theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
     <p>
       In fact, try resizing this page. Everything flows super nicely as you'll see.
     </p>
-    <button id='switch'>Switch theme</button>
+    <button type="button" id='switch'>Switch theme</button>
 
     <h2>Element demos</h2>
     <p>

--- a/script.js
+++ b/script.js
@@ -1,45 +1,70 @@
-(function () {
-  const switchBtn = document.getElementById('switch');
-  const stylesheet = document.getElementById('stylesheet');
-  const darkMql = matchMedia('(prefers-color-scheme: dark)');
-  const lightMql = matchMedia('(prefers-color-scheme: light)');
+(function (ThemeSwitcher) {
+  const themeSwitcher = new ThemeSwitcher('stylesheet');
+  const themeSwitch = document.getElementById('theme-switch');
   const themes = {
-    dark: '../dist/dark.css',
-    darkStandalone: '../dist/dark.standalone.css',
-    light: '../dist/light.css',
-    lightStandalone: '../dist/light.standalone.css'
+    dark: 'dark',
+    darkStandalone: 'dark.standalone',
+    light: 'light',
+    lightStandalone: 'light.standalone'
+  };
+  const getSwitchThemePath = function () {
+    // Case: switch to "light.standalone.css"
+    if (
+      (themeSwitcher.current === themes.dark) && themeSwitcher.isDark ||
+      (themeSwitcher.current === themes.light) && themeSwitcher.isDark ||
+      themeSwitcher.current === themes.darkStandalone
+    ) {
+      return themes.lightStandalone
+
+    // Case: switch to "dark.standalone.css"
+    } else if (
+      (themeSwitcher.current === themes.dark) && themeSwitcher.isLight ||
+      (themeSwitcher.current === themes.light) && themeSwitcher.isLight ||
+      themeSwitcher.current === themes.lightStandalone
+    ) {
+      return themes.darkStandalone;
+
+    // Case: switch to "light.css"
+    } else if (themeSwitcher.current === themes.dark) {
+      return themes.light;
+
+    // Case: switch to "dark.css"
+    } else if (themeSwitcher.current === themes.light) {
+      return themes.dark;
+
+    // Case: switch destination is unknown
+    } else {
+      return themeSwitcher.current;
+    }
   };
 
-  switchBtn.addEventListener('click', function() {
-    const readTheme = stylesheet.getAttribute('href');
-    if (readTheme === themes.dark) {
-      if (darkMql.matches) {
-        stylesheet.href = themes.lightStandalone
-      } else if (lightMql.matches) {
-        stylesheet.href = themes.darkStandalone
-      } else {
-        stylesheet.href = themes.light
-      }
-    } else if (readTheme === themes.darkStandalone) {
-      stylesheet.href = themes.lightStandalone
-    } else if (readTheme === themes.light) {
-      if (darkMql.matches) {
-        stylesheet.href = themes.lightStandalone
-      } else if (lightMql.matches) {
-        stylesheet.href = themes.darkStandalone
-      } else {
-        stylesheet.href = themes.dark
-      }
-    } else if (readTheme === themes.lightStandalone) {
-      stylesheet.href = themes.darkStandalone
-    }
+  themeSwitch.addEventListener('click', function() {
+    themeSwitcher.switch(getSwitchThemePath());
   });
+})(
+  (function () {
+    const ThemeSwitcher = function(stylesheet) {
+      const darkSchemeMql = matchMedia('(prefers-color-scheme: dark)');
+      const lightSchemeMql = matchMedia('(prefers-color-scheme: light)');
 
-  darkMql.addListener(function (mql) {
-    if (mql.matches) {
-      stylesheet.href = themes.dark;
-    } else {
-      stylesheet.href = themes.light;
-    }
-  })
-})();
+      this.themeDir = '../dist/';
+      this.stylesheet = document.getElementById(stylesheet);
+      this.current = this.getThemeName(this.stylesheet.href);
+      this.isDark = darkSchemeMql.matches;
+      this.isLight = lightSchemeMql.matches;
+    };
+
+    ThemeSwitcher.prototype = {
+      switch: function (themeName) {
+        this.stylesheet.href = this.themeDir + themeName + '.css';
+        this.current = themeName;
+      },
+      getThemeName: function () {
+        const reg = new RegExp(this.themeDir + '(|.+?).css');
+        return stylesheet.getAttribute('href').replace(reg, '$1');
+      }
+    };
+
+    return ThemeSwitcher;
+  })()
+);

--- a/script.js
+++ b/script.js
@@ -1,13 +1,13 @@
 (function (ThemeSwitcher) {
   const themeSwitcher = new ThemeSwitcher('stylesheet');
-  const themeSwitch = document.getElementById('theme-switch');
+  const themeSwitchBtn = document.getElementById('switch');
   const themes = {
     dark: 'dark',
     darkStandalone: 'dark.standalone',
     light: 'light',
     lightStandalone: 'light.standalone'
   };
-  const getSwitchThemePath = function () {
+  const getSwitchThemeName = function () {
     // Case: switch to "light.standalone.css"
     if (
       (themeSwitcher.current === themes.dark) && themeSwitcher.isDark ||
@@ -37,21 +37,45 @@
       return themeSwitcher.current;
     }
   };
+  const getGeneralThemeName = function () {
+    return themeSwitcher.current.replace(/\.standalone/g, '');
+  };
 
-  themeSwitch.addEventListener('click', function() {
-    themeSwitcher.switch(getSwitchThemePath());
+  themeSwitchBtn.addEventListener('click', function() {
+    themeSwitcher.switch(getSwitchThemeName());
   });
+
+  themeSwitcher.onChangeDark = function () {
+    themeSwitcher.switch(getGeneralThemeName());
+  };
+
+  themeSwitcher.onChangeLight = function () {
+    themeSwitcher.switch(getGeneralThemeName());
+  };
 })(
   (function () {
     const ThemeSwitcher = function(stylesheet) {
       const darkSchemeMql = matchMedia('(prefers-color-scheme: dark)');
       const lightSchemeMql = matchMedia('(prefers-color-scheme: light)');
+      const that = this;
 
       this.themeDir = '../dist/';
       this.stylesheet = document.getElementById(stylesheet);
       this.current = this.getThemeName(this.stylesheet.href);
       this.isDark = darkSchemeMql.matches;
       this.isLight = lightSchemeMql.matches;
+
+      darkSchemeMql.addListener(function (mql) {
+        if (mql.matches && typeof that.onChangeDark === 'function') {
+          that.onChangeDark()
+        }
+      });
+
+      lightSchemeMql.addListener(function (mql) {
+        if (mql.matches && typeof that.onChangeLight === 'function') {
+          that.onChangeLight()
+        }
+      });
     };
 
     ThemeSwitcher.prototype = {
@@ -62,7 +86,9 @@
       getThemeName: function () {
         const reg = new RegExp(this.themeDir + '(|.+?).css');
         return stylesheet.getAttribute('href').replace(reg, '$1');
-      }
+      },
+      onChangeDark: null,
+      onChangeLight: null
     };
 
     return ThemeSwitcher;

--- a/script.js
+++ b/script.js
@@ -1,4 +1,36 @@
-document.getElementById('switch').addEventListener('click', function() {
+(function () {
+  const switchBtn = document.getElementById('switch');
   const stylesheet = document.getElementById('stylesheet');
-  stylesheet.href = stylesheet.href.replace(/dark|light/, function(replaced) { return replaced === 'dark' ? 'light' : 'dark' });
-});
+  const mql = matchMedia('(prefers-color-scheme: dark)');
+  const themes = {
+    dark: '../dist/dark.css',
+    darkStandalone: '../dist/dark.standalone.css',
+    light: '../dist/light.css',
+    lightStandalone: '../dist/light.standalone.css'
+  };
+
+  switchBtn.addEventListener('click', function() {
+    switch (stylesheet.getAttribute('href')) {
+      case themes.dark:
+        stylesheet.href = mql.matches ? themes.lightStandalone : themes.darkStandalone;
+        break;
+      case themes.darkStandalone:
+        stylesheet.href = themes.lightStandalone;
+        break;
+      case themes.light || themes.lightStandalone:
+        stylesheet.href = mql.matches ? themes.lightStandalone : themes.darkStandalone;
+        break;
+      case themes.lightStandalone:
+        stylesheet.href = themes.darkStandalone;
+        break;
+    }
+  });
+
+  mql.addListener(function (mql) {
+    if (mql.matches) {
+      stylesheet.href = themes.dark;
+    } else {
+      stylesheet.href = themes.light;
+    }
+  })
+})();

--- a/script.js
+++ b/script.js
@@ -1,7 +1,8 @@
 (function () {
   const switchBtn = document.getElementById('switch');
   const stylesheet = document.getElementById('stylesheet');
-  const mql = matchMedia('(prefers-color-scheme: dark)');
+  const darkMql = matchMedia('(prefers-color-scheme: dark)');
+  const lightMql = matchMedia('(prefers-color-scheme: light)');
   const themes = {
     dark: '../dist/dark.css',
     darkStandalone: '../dist/dark.standalone.css',
@@ -10,23 +11,31 @@
   };
 
   switchBtn.addEventListener('click', function() {
-    switch (stylesheet.getAttribute('href')) {
-      case themes.dark:
-        stylesheet.href = mql.matches ? themes.lightStandalone : themes.darkStandalone;
-        break;
-      case themes.darkStandalone:
-        stylesheet.href = themes.lightStandalone;
-        break;
-      case themes.light || themes.lightStandalone:
-        stylesheet.href = mql.matches ? themes.lightStandalone : themes.darkStandalone;
-        break;
-      case themes.lightStandalone:
-        stylesheet.href = themes.darkStandalone;
-        break;
+    const readTheme = stylesheet.getAttribute('href');
+    if (readTheme === themes.dark) {
+      if (darkMql.matches) {
+        stylesheet.href = themes.lightStandalone
+      } else if (lightMql.matches) {
+        stylesheet.href = themes.darkStandalone
+      } else {
+        stylesheet.href = themes.light
+      }
+    } else if (readTheme === themes.darkStandalone) {
+      stylesheet.href = themes.lightStandalone
+    } else if (readTheme === themes.light) {
+      if (darkMql.matches) {
+        stylesheet.href = themes.lightStandalone
+      } else if (lightMql.matches) {
+        stylesheet.href = themes.darkStandalone
+      } else {
+        stylesheet.href = themes.dark
+      }
+    } else if (readTheme === themes.lightStandalone) {
+      stylesheet.href = themes.darkStandalone
     }
   });
 
-  mql.addListener(function (mql) {
+  darkMql.addListener(function (mql) {
     if (mql.matches) {
       stylesheet.href = themes.dark;
     } else {


### PR DESCRIPTION
I updated script.js for https://github.com/kognise/water.css/issues/84.
There are plans to display the status of the color scheme of the selected theme or device, but for the moment we are fixing only the switching function.

- Switch to "standalone" after clicking "Switch theme".
- If you change the device scheme, it will switch to the normal version.
- Create "ThemeSwitcher" considering "version picker".

There are some suggestions for future work.

- Add JavaScript development environment using babel.(Bundle by gulp because you already use gulp)
    - Improve code prospects.
    - Easy browser support.
- Integration of "Version picker" and "Switch theme". (https://github.com/kognise/water.css/issues/27)
    - Status messages are integrated here. 
    - There are also "standalone" and "legacy", so it is difficult for the user to understand the situation if there is only one "Switch theme".