### PR TITLE
Break words when word wrapping

### DIFF
--- a/src/parts/_base.css
+++ b/src/parts/_base.css
@@ -5,6 +5,7 @@ body {
   max-width: 800px;
   margin: 20px auto;
   padding: 0 10px;
+  word-wrap: break-word;
 
   color: var(--text-main);
   background: var(--background-body);


### PR DESCRIPTION
Prevents long strings of characters (say, "AAAAAAAAAAAAAAAAAAAAAAAA" for example) from going out of the content area and making you have to scroll.