### PR TITLE
Add run on Repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "yarn dev"

--- a/README.md
+++ b/README.md
@@ -141,12 +141,10 @@ If you decide to contribute, after downloading a copy of the repository make sur
 $ yarn dev
 ```
 
+**Alternatively, just click this button to develop in Repl.it, a supercool in-browser IDE!** [![Run on Repl.it](https://repl.it/badge/github/kognise/water.css)](https://repl.it/github/kognise/water.css)
+
 Before submitting your first pull request, make sure to check out our [Contributing Guide](https://github.com/kognise/water.css/tree/master/.github/CONTRIBUTING.md)!  
 Thanks for taking the time to contribute :)
-
-## Contributing
-
-Please see [CONTRIBUTING](.github/CONTRIBUTING.md) for details.
 
 ## Todos
 


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it. It adds a `.replit` configuration file and a Repl.it badge to the `README`.

You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://staging.repl.it/@Kognise/watercss-16).

To be transparent, I haven't been as active maintaining Water.css as I should've been, but I'm almost ready to focus my efforts back on this **awesome** project.