### PR TITLE
fix telephone.html being recognized as tel: etc.

### DIFF
--- a/src/parts/_typography.css
+++ b/src/parts/_typography.css
@@ -62,15 +62,15 @@ address {
   font-style: normal;
 }
 
-a[href^='mailto']::before {
+a[href^='mailto\:']::before {
   content: '📧 ';
 }
 
-a[href^='tel']::before {
+a[href^='tel\:']::before {
   content: '📞 ';
 }
 
-a[href^='sms']::before {
+a[href^='sms\:']::before {
   content: '💬 ';
 }
 


### PR DESCRIPTION
A link like this: <a href="telephone.html">telephone</a> is recognized as phone link and an icon is added next to it. This PR adds a : requirement in the href (also for mailto and sms).