### PR TITLE
Add Print Stylesheet

### DIFF
--- a/src/parts/_core.css
+++ b/src/parts/_core.css
@@ -5,3 +5,4 @@
 @import '_links.css';
 @import '_code.css';
 @import '_misc.css';
+@import '_print.css';

--- a/src/parts/_print.css
+++ b/src/parts/_print.css
@@ -1,0 +1,53 @@
+@media print {
+  body,
+  pre,
+  code,
+  summary,
+  details,
+  button,
+  input,
+  textarea {
+    background-color: #fff;
+  }
+
+  button,
+  input,
+  textarea {
+    border: 1px solid #000;
+  }
+
+  body,
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  pre,
+  code,
+  button,
+  input,
+  textarea,
+  footer,
+  summary,
+  strong {
+    color: #000;
+  }
+
+  summary::marker {
+    color: #000;
+  }
+
+  summary::-webkit-details-marker {
+    color: #000;
+  }
+
+  tbody tr:nth-child(even) {
+    background-color: #f2f2f2;
+  }
+
+  a {
+    color: #00f;
+    text-decoration: underline;
+  }
+}


### PR DESCRIPTION
This PR adds a media query that overrides styles when printing. I decided to use fixed colors instead of importing all the light theme variables as @kylejrp suggested, but I'm happy to do it the other way if that's clearly better.

This fixes #188.