### PR TITLE
feat: respect cols/rows attribute on textarea

### DIFF
--- a/src/parts/_forms.css
+++ b/src/parts/_forms.css
@@ -58,10 +58,17 @@ textarea {
 }
 
 textarea {
+  display: block;
   margin-right: 0;
-  width: 100%;
   box-sizing: border-box;
   resize: vertical;
+}
+
+textarea:not([cols]) {
+  width: 100%;
+}
+
+textarea:not([rows]) {
   min-height: 140px;
 }
 


### PR DESCRIPTION
Only applies `width` and `min-height` to `textarea` if the `cols`/`rows` attribute aren't there so you can still use those attributes to control size.