### PR TITLE
feat: scrollbar styles for firefox

### DIFF
--- a/src/parts/_base.css
+++ b/src/parts/_base.css
@@ -1,3 +1,8 @@
+html {
+  scrollbar-color: var(--scrollbar-thumb) var(--background-body);
+  scrollbar-width: thin;
+}
+
 body {
   font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', 'Segoe UI Emoji', 'Apple Color Emoji', 'Noto Color Emoji', sans-serif;
   line-height: 1.4;


### PR DESCRIPTION
Adding scrollbar styles that use the new scrollbar properties which are only supported in Firefox so far.

Really not sure where to put this, `_base` (because `html`) or `_misc` (because webkit scrollbar is there) – or move webkit scrollbar styles over to `_base`?