### PR TITLE
Added color --text-bright to the selection in _misc

### DIFF
--- a/src/parts/_misc.css
+++ b/src/parts/_misc.css
@@ -61,6 +61,7 @@ tbody tr:nth-child(even) {
 
 ::selection {
   background-color: var(--selection);
+  color: var(--text-bright);
 }
 
 details {


### PR DESCRIPTION
This pull request focused on changing the contrasting colors of the selection background color and text color to make it more readable. The original code for ::selection was as follows:
 ::selection {
  background-color: var(--selection);
}
The new code is now this:
::selection {
  background-color: var(--selection);
  color: var(--text-bright);
}

The contrast checker scores for the light and dark theme are as described here:
light-theme: 7.83:1
dark-theme: 4.72:1
In the attached screenshots you can see the improved readability of the selection of text.
![dark-theme](https://user-images.githubusercontent.com/40209521/86050263-35ee9b80-ba19-11ea-9cdc-5905cf2b33af.jpg)
![light-theme](https://user-images.githubusercontent.com/40209521/86050273-39822280-ba19-11ea-968c-3efd493853ed.jpg)

