### PR TITLE
Add styling for color input, example to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -181,6 +181,11 @@
 
       <br />
 
+      <label for='fcolor'>Select your favorite color</label>
+      <input type='color' name='fcolor' id='fcolor' />
+
+      <br />
+
       <div>
         <label for='volume'>Volume</label>
         <input type='range' name='volume' id='volume' min='0' max='11' />

--- a/src/parts/_forms.css
+++ b/src/parts/_forms.css
@@ -31,6 +31,11 @@ select {
   outline: none;
 }
 
+input[type='color'] {
+  min-height: 2rem;
+  padding: 8px;
+}
+
 input,
 select,
 button,


### PR DESCRIPTION
The HTML tag `<input type='color'>` is now styled correctly on Chromium and Firefox based browsers.

They look slightly different across browsers due to differences in how `padding` is handled for this element by different renderers, but it looks acceptable on both browsers.

The `index.html` example site has also been updated to demonstrate the new element.

This addresses issue #178.