### PR TITLE
Improve cross-platform form controls

### DIFF
--- a/.changeset/fuzzy-news-teach.md
+++ b/.changeset/fuzzy-news-teach.md
@@ -1,0 +1,5 @@
+---
+"water.css": patch
+---
+
+Improved form control styles (checkboxes and radios) across platforms/browsers

--- a/src/parts/_forms.css
+++ b/src/parts/_forms.css
@@ -37,8 +37,19 @@ input[type='color'] {
 
 input[type='checkbox'],
 input[type='radio'] {
-  height: 1em;
-  width: 1em;
+  transform: scale(1.4);
+}
+
+input[type='submit']:active,
+input[type='button']:active,
+input[type='range']:active,
+button:active {
+  transform: translateY(2px);
+}
+
+input[type='checkbox']:active,
+input[type='radio']:active {
+  transform: translateY(2px) scale(1.4);
 }
 
 input[type='radio'] {
@@ -46,7 +57,7 @@ input[type='radio'] {
 }
 
 input {
-  vertical-align: top;
+  vertical-align: middle;
 }
 
 label {
@@ -112,15 +123,6 @@ select:focus,
 button:focus,
 textarea:focus {
   box-shadow: 0 0 0 2px var(--focus);
-}
-
-input[type='checkbox']:active,
-input[type='radio']:active,
-input[type='submit']:active,
-input[type='button']:active,
-input[type='range']:active,
-button:active {
-  transform: translateY(2px);
 }
 
 input:disabled,


### PR DESCRIPTION
This updates the form control styles (checkbox and radio) to look better across browsers and platforms.

The main issue is that Firefox doesn't respect custom sizes, so instead I used `transform: scale(1.5)`. This should be backwards compatible unless people are doing weird transform styles. In the worst case it'll just cause the checkbox to be a bit smaller or animate weirdly.

This looks great everywhere but Safari where there's a lot of clipping:

![image](https://user-images.githubusercontent.com/42556441/94944233-f23b8000-04a6-11eb-9bcd-85ae3d5d95f7.png)
