### PR TITLE
better button color inside table

### DIFF
--- a/.changeset/stale-dodos-chew.md
+++ b/.changeset/stale-dodos-chew.md
@@ -1,0 +1,5 @@
+---
+"water.css": patch
+---
+
+Better button color inside table.

--- a/src/parts/_misc.css
+++ b/src/parts/_misc.css
@@ -37,7 +37,15 @@ tfoot {
 }
 
 tbody tr:nth-child(even) {
+  background-color: var(--background);
+}
+
+tbody tr:nth-child(even) button {
   background-color: var(--background-alt);
+}
+
+tbody tr:nth-child(even) button:hover {
+  background-color: var(--background-body);
 }
 
 ::-webkit-scrollbar {


### PR DESCRIPTION
Closes #181

As a default, the button is gray and becoming darker when hover. But table even cells are already gray, so I make the button light gray and lighter when hover.