### PR TITLE
Update docs for better security in CDN links

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -121,9 +121,9 @@
       </header>
 
       <div id="link-snippet-container">
-        <pre id="link-snippet-auto"><code>&lt;link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/water.css@2/out/water.css" integrity="sha256-HfKK0UZwALXyrCbFrMcV/bMDenCCcD3oBy4NUWLM7LA=" crossorigin="anonymous"></code></pre>
-        <pre hidden id="link-snippet-dark"><code>&lt;link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/water.css@2/out/dark.css" integrity="sha256-O+6TE8NRXU6Yayc7uMzRMYJ9pTXUAypXKcVl3OOHL9Y=" crossorigin="anonymous"></code></pre>
-        <pre hidden id="link-snippet-light"><code>&lt;link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/water.css@2/out/light.css" integrity="sha256-uCRof5s65uvYVRkezLBU47V7YuK9CGAMDa1QkLPEZqE=" crossorigin="anonymous"></code></pre>
+        <pre id="link-snippet-auto"><code>&lt;link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/water.css@2.0.0/out/water.css" integrity="sha256-HfKK0UZwALXyrCbFrMcV/bMDenCCcD3oBy4NUWLM7LA=" crossorigin="anonymous"></code></pre>
+        <pre hidden id="link-snippet-dark"><code>&lt;link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/water.css@2.0.0/out/dark.css" integrity="sha256-O+6TE8NRXU6Yayc7uMzRMYJ9pTXUAypXKcVl3OOHL9Y=" crossorigin="anonymous"></code></pre>
+        <pre hidden id="link-snippet-light"><code>&lt;link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/water.css@2.0.0/out/light.css" integrity="sha256-uCRof5s65uvYVRkezLBU47V7YuK9CGAMDa1QkLPEZqE=" crossorigin="anonymous"></code></pre>
       </div>
 
       <h3>Options</h3>

--- a/docs/index.html
+++ b/docs/index.html
@@ -121,9 +121,9 @@
       </header>
 
       <div id="link-snippet-container">
-        <pre id="link-snippet-auto"><code>&lt;link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/water.css@2/out/water.css"></code></pre>
-        <pre hidden id="link-snippet-dark"><code>&lt;link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/water.css@2/out/dark.css"></code></pre>
-        <pre hidden id="link-snippet-light"><code>&lt;link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/water.css@2/out/light.css"></code></pre>
+        <pre id="link-snippet-auto"><code>&lt;link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/water.css@2/out/water.css" integrity="sha256-HfKK0UZwALXyrCbFrMcV/bMDenCCcD3oBy4NUWLM7LA=" crossorigin="anonymous"></code></pre>
+        <pre hidden id="link-snippet-dark"><code>&lt;link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/water.css@2/out/dark.css" integrity="sha256-O+6TE8NRXU6Yayc7uMzRMYJ9pTXUAypXKcVl3OOHL9Y=" crossorigin="anonymous"></code></pre>
+        <pre hidden id="link-snippet-light"><code>&lt;link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/water.css@2/out/light.css" integrity="sha256-uCRof5s65uvYVRkezLBU47V7YuK9CGAMDa1QkLPEZqE=" crossorigin="anonymous"></code></pre>
       </div>
 
       <h3>Options</h3>


### PR DESCRIPTION
Added a [subresource integrity check attribute](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) and [crossorigin anonymou attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin).

This will ensure that anyone using the jsdelivr CDN won't be vulnerable to a security incident where a malicious stylesheet is served. ([Source 1](https://shkspr.mobi/blog/2020/10/please-stop-using-cdns-for-external-javascript-libraries/), [Source 2](https://www.smashingmagazine.com/2019/04/understanding-subresource-integrity/))

We will need to make a point of updating the integrity attributes when we release new versions. There's a [page on jsdelivr](https://www.jsdelivr.com/package/npm/water.css?path=out) where you can copy the HTML + SRI:
[![image](https://user-images.githubusercontent.com/6742479/95689546-54426680-0bc6-11eb-9c4e-89ce2dbca699.png)](https://www.jsdelivr.com/package/npm/water.css?path=out)

This also prevents people from easily changing the installation link from `water.css` to `water.min.css` since the integrity checks are different. We might want to add a `[ ] Minified` checkbox.