### PR TITLE
Fix color of code and strong tags inside links

### DIFF
--- a/.changeset/tiny-ravens-decide.md
+++ b/.changeset/tiny-ravens-decide.md
@@ -1,0 +1,5 @@
+---
+"water.css": patch
+---
+
+Fix color of `<code>` and `<strong>` tags inside links

--- a/src/parts/_typography.css
+++ b/src/parts/_typography.css
@@ -82,3 +82,8 @@ mark {
   padding: 0 2px 0 2px;
   color: #000;
 }
+
+a > code,
+a > strong {
+  color: inherit;
+}


### PR DESCRIPTION
The default stylesheet, if you create a strong link or code, it will not be noticable as links.

```markdown
[**text**](#)
[`text`](#)
```

This PR fixes this.

| Before | After |
|-|-|
| ![image](https://user-images.githubusercontent.com/193136/102712509-735f2200-42f4-11eb-8aec-66fd010dda63.png) | ![image](https://user-images.githubusercontent.com/193136/102712522-870a8880-42f4-11eb-8a47-875dd3b3f700.png) |
