### PR TITLE
Update package entrypoint

### DIFF
--- a/.changeset/thirty-buckets-invent.md
+++ b/.changeset/thirty-buckets-invent.md
@@ -1,0 +1,5 @@
+---
+"water.css": patch
+---
+
+Update main package entrypoint

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "water.css",
   "version": "2.0.0",
   "description": "A drop-in collection of CSS styles to make simple websites just a little nicer",
-  "main": "index.js",
+  "main": "out/water.css",
   "scripts": {
     "build": "gulp build",
     "dev": "gulp watch",


### PR DESCRIPTION
## Changes

This updates the `package.json` `"main"` entrypoint to the actual CSS (the core of the library), rather than the current `.index.js` file.

```diff
- "main": "index.js",
+ "main": "out/water.css",
```

### Further explanation

If you tried to import `import water from 'water.css'` using a bundler like webpack or Snowpack, it fails:

```
Error: Cannot find module './gulpfile'
```

That’s because if you look at the actual [package published to npm](https://unpkg.com/browse/water.css@2.0.0/), there is no `gulpfile.js`! So it doesn’t make sense as the main entry anyway.

However, setting the main entrypoint to `"main": "out/water.css"` instead allows for easier consumption, without affecting any of the local dev setup. It’s just more user-friendly without any drawbacks.

### Other suggestions

It may also be better to not publish `index.js` to npm as well? I can also make that a part of this PR, if desired.