### PR TITLE
Replace deprecated ::-webkit-details-marker

### DIFF
--- a/.changeset/breezy-cows-do.md
+++ b/.changeset/breezy-cows-do.md
@@ -1,0 +1,5 @@
+---
+"water.css": patch
+---
+
+Replace deprecated ::-webkit-details-marker

--- a/src/parts/_misc.css
+++ b/src/parts/_misc.css
@@ -113,7 +113,7 @@ details > :not(summary) {
   margin-top: 0;
 }
 
-summary::-webkit-details-marker {
+summary::marker {
   color: var(--text-main);
 }
 

--- a/src/parts/_print.css
+++ b/src/parts/_print.css
@@ -38,10 +38,6 @@
     color: #000;
   }
 
-  summary::-webkit-details-marker {
-    color: #000;
-  }
-
   tbody tr:nth-child(even) {
     background-color: #f2f2f2;
   }


### PR DESCRIPTION
Replaces all references to `summary::-webkit-details-marker` as it is being deprecated.
Source: https://chromestatus.com/feature/6730096436051968

Closes #245 