### PR TITLE
Remove sourcemap references from built files

### DIFF
--- a/.changeset/itchy-hairs-beg.md
+++ b/.changeset/itchy-hairs-beg.md
@@ -1,0 +1,5 @@
+---
+"water.css": patch
+---
+
+Remove sourcemap references from built files

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -58,7 +58,6 @@ const style = () => {
   return (
     gulp
       .src(paths.styles.src)
-      .pipe(sourcemaps.init())
       .pipe(postcss([postcssImport(), postcssColorModFunction(), postcssInlineSvg()]))
 
       .pipe(startDiff())
@@ -69,11 +68,8 @@ const style = () => {
       .pipe(postcss([autoprefixer()]))
       .pipe(endDiff('autoprefixer'))
 
-      .pipe(sourcemaps.write('.'))
       .pipe(flatten()) // Put files in out/*, not out/builds/*
       .pipe(gulp.dest(paths.styles.dest))
-
-      .pipe(filter('**/*.css')) // Remove sourcemaps from the pipeline
 
       // <minifying>
       .pipe(startDiff())
@@ -82,11 +78,9 @@ const style = () => {
       .pipe(rename({ suffix: '.min' }))
       // </minifying>
 
-      .pipe(sourcemaps.write('.'))
       .pipe(gulp.dest(paths.styles.dest))
       .pipe(gulp.dest(paths.docs.dest + '/water.css'))
 
-      .pipe(filter('**/*.css')) // Remove sourcemaps from the pipeline
       .pipe(sizereport({ gzip: true, total: false, title: 'SIZE REPORT' }))
       .pipe(browserSync.stream())
   )


### PR DESCRIPTION
Since the sourcemaps are not included in distributed files they should probably not be referenced in the files. This removes that part from the build steps.