### PR TITLE
Reduce input selector specificity for input display property

### DIFF
--- a/.changeset/large-days-judge.md
+++ b/.changeset/large-days-judge.md
@@ -1,0 +1,5 @@
+---
+"water.css": patch
+---
+
+Reduce input selector specificity for display property to prevent overriding user's css. Fixes #78 and #82

--- a/src/parts/_forms.css
+++ b/src/parts/_forms.css
@@ -9,9 +9,14 @@ input[type='radio'] {
   cursor: pointer;
 }
 
-input:not([type='checkbox']):not([type='radio']),
+input,
 select {
   display: block;
+}
+
+[type='checkbox'],
+[type='radio'] {
+  display: initial;
 }
 
 input,


### PR DESCRIPTION
To prevent overriding user's css.
Closes #78
Closes #82