### PR TITLE
Fix inline quotation line height

### DIFF
--- a/src/parts/_typography.css
+++ b/src/parts/_typography.css
@@ -51,6 +51,10 @@ q {
   font-style: italic;
 }
 
+q {
+  line-height: 2.2em;
+}
+
 blockquote > footer {
   font-style: normal;
   border: 0;


### PR DESCRIPTION
PR related to [Issue 261](https://github.com/kognise/water.css/issues/261).
Fix the line height of the <q> tag so its border won't overlap adjacent lines.
