### PR TITLE
Add monospace system font stack

### DIFF
--- a/.changeset/friendly-meals-cheat.md
+++ b/.changeset/friendly-meals-cheat.md
@@ -1,0 +1,5 @@
+---
+"water.css": minor
+---
+
+Add monospace system font stack

--- a/src/parts/_code.css
+++ b/src/parts/_code.css
@@ -8,6 +8,13 @@ time {
   font-size: 1em;
 }
 
+pre,
+code,
+samp,
+kbd {
+  font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace;
+}
+
 pre > code {
   padding: 10px;
   display: block;

--- a/src/parts/_code.css
+++ b/src/parts/_code.css
@@ -11,8 +11,9 @@ time {
 pre,
 code,
 samp,
-kbd {
-  font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace;
+kbd,
+var {
+  font-family: ui-monospace, 'SFMono-Regular', 'SF Mono', 'Menlo', 'Consolas', 'Liberation Mono', monospace;
 }
 
 pre > code {
@@ -24,7 +25,6 @@ pre > code {
 var {
   color: var(--variable);
   font-style: normal;
-  font-family: monospace;
 }
 
 kbd {


### PR DESCRIPTION
Let's add a system font stack for monospace fonts to give monospace elements a pleasing default font.

This monospace font stack is based on [GitHub's Primer design system](
https://github.com/primer/css/blob/main/src/support/variables/typography.scss#L39).
