### PR TITLE
Unprefix `-webkit-appearance`

### DIFF
--- a/.changeset/ten-berries-explode.md
+++ b/.changeset/ten-berries-explode.md
@@ -1,0 +1,5 @@
+---
+"water.css": patch
+---
+
+Unprefix `-webkit-appearance`

--- a/src/parts/_forms.css
+++ b/src/parts/_forms.css
@@ -82,7 +82,7 @@ input[type='range'],
 select,
 button,
 textarea {
-  -webkit-appearance: none;
+  appearance: none;
 }
 
 textarea {

--- a/src/parts/_range.css
+++ b/src/parts/_range.css
@@ -22,7 +22,7 @@ input[type='range']::-webkit-slider-thumb {
   width: 20px;
   border-radius: 50%;
   background: var(--border);
-  -webkit-appearance: none;
+  appearance: none;
   margin-top: -7px;
 }
 


### PR DESCRIPTION
[`-webkit-appearance` should be unprefixed][1].

Autoprefixer will add in the necessary vendor prefixes on build.

[1]: https://developer.mozilla.org/en-US/docs/Web/CSS/appearance