### PR TITLE
Prevent submitting the demo form

### DIFF
--- a/.changeset/hungry-eagles-shout.md
+++ b/.changeset/hungry-eagles-shout.md
@@ -1,0 +1,5 @@
+---
+"water.css": patch
+---
+
+Prevent submitting the demo form

--- a/docs/index.html
+++ b/docs/index.html
@@ -198,7 +198,7 @@
     <p>This is supposed to be a demo page so we need more elements!</p>
 
     <h3 id="form-elements">Form elements</h3>
-    <form>
+    <form onsubmit="return false;">
       <label for="email">Email</label>
       <input type="email" name="email" id="email" placeholder="john.doe@gmail.com" />
 


### PR DESCRIPTION
When the submit button on the demo form is pressed, the form is actually submitted and the page is refreshed.

Let's prevent the form from submitting by adding a dummy onsubmit handler that returns false.