### PR TITLE
feat(radio): change focus ring to match round input

### DIFF
--- a/.changeset/nasty-files-care.md
+++ b/.changeset/nasty-files-care.md
@@ -1,0 +1,5 @@
+---
+"water.css": minor
+---
+
+Changed radio button outline on :focus from square to circle

--- a/.changeset/poor-falcons-drum.md
+++ b/.changeset/poor-falcons-drum.md
@@ -1,0 +1,5 @@
+---
+"water.css": minor
+---
+
+Changed radio focus from square to circle, per issue 278

--- a/src/parts/_forms.css
+++ b/src/parts/_forms.css
@@ -123,6 +123,11 @@ textarea:focus {
   box-shadow: 0 0 0 2px var(--focus);
 }
 
+input[type='radio']:focus {
+  filter: drop-shadow(2px 2px 2px var(--focus)) drop-shadow(-2px -2px 2px var(--focus)) drop-shadow(-2px 2px 2px var(--focus)) drop-shadow(2px -2px 2px var(--focus));
+  clip-path: circle(0.6rem at 50% 50%);
+}
+
 input[type='checkbox']:active,
 input[type='radio']:active,
 input[type='submit']:active,


### PR DESCRIPTION
## Description
This uses a drop-shadow filter and clip path to create a round focus indicator on radio inputs. 
Issue #278 

### Method
- A box-shadow can only apply square shadows to an element, resulting in a mismatched focus indicator. Screenshot of the original focus state:
<img width="499" alt="Screen Shot 2022-10-24 at 8 25 59 AM" src="https://user-images.githubusercontent.com/25614178/197525262-42cd1386-6618-452b-b70c-7cfbb0afd6cb.png">

- Instead of box-shadow, I used a drop-shadow filter. Drop-shadow filter does not yet support the spread variable that box-shadow has, so we cannot create the unblurred solid 2px shadow that box-shadow allows. Instead, I used 4 layered shadow filters which cover a wide enough area to build the focus indicator. Screenshot of the four layered shadow filters:
<img width="501" alt="Screen Shot 2022-10-24 at 8 32 05 AM" src="https://user-images.githubusercontent.com/25614178/197526162-2e82fe7a-7118-4cc4-ade2-dfb376a6e838.png">


- The shadow is then limited to closely match the original 2 pixel solid box shadow spread by creating a circular clip path which slightly overshoots the edge of the component to allow approximately 2 pixels of shadow to show through:
<img width="507" alt="Screen Shot 2022-10-24 at 8 25 20 AM" src="https://user-images.githubusercontent.com/25614178/197525734-19627764-3b24-4d19-ac85-2476fae75613.png">

## How and where has this been tested?
 - Chrome 106 for macOS
 - Firefox 106 for macOS
 - Safari 16 for macOS

## Screenshots
<img width="549" alt="Screen Shot 2022-10-23 at 3 09 34 PM" src="https://user-images.githubusercontent.com/25614178/197415268-42f1026f-e365-4941-8a5d-1e756b2d3d30.png">

## Browser Compatibility
Although this is compatible with Safari, it is worth noting that an existing issue with the display of radio inputs in Safari results in cropping of the input. This was a pre-existing issue due to the width, height, and font size on the input. I recommend that this be resolved in a separate issue.

Safari screenshot:
<img width="532" alt="water-safari-radio-issue" src="https://user-images.githubusercontent.com/25614178/197415351-dc397f7f-29a6-4fc3-ad75-2b308cb4d4b9.png">

Please let me know if any changes are needed and I would be glad to take care of it.