### PR TITLE
Customizing <a> tag link with a button style

### DIFF
--- a/.changeset/add-button.md
+++ b/.changeset/add-button.md
@@ -1,0 +1,4 @@
+---
+"water.css": patch
+---
+Customizing <a> tag link with a button style

--- a/docs/index.html
+++ b/docs/index.html
@@ -87,9 +87,8 @@
 
     <div class="row">
       <div>
-        <a href="#installation"><b>Get it already!</b></a>
-        <br />
-        <a href="https://github.com/kognise/water.css"><b>GitHub</b></a>
+        <a href="#installation" class="header-button">Get it already!</a>
+        <a href="https://github.com/kognise/water.css" class="header-button">GitHub</a>
       </div>
 
       <a

--- a/docs/style.css
+++ b/docs/style.css
@@ -63,3 +63,17 @@ body > footer {
   align-items: center;
   justify-content: space-between;
 }
+
+.header-button {
+  display: inline-block;
+  margin-top: 15px;
+  margin-right: 10px;
+  padding: 10px;
+  background-color: var(--button-base);
+  color: var(--text-bright);
+  border-radius: 10%;
+}
+
+.header-button:hover {
+  background-color: var(--button-hover);
+}


### PR DESCRIPTION
## Description
Added two buttons on the front page of water.css for `Get it already!` and `Github` substituting the old text-only links. Customized the style in accordance with the rest of the page and successfully verified the code with `yarn validate`

Closes #338 

## Edited files path
```
docs>index.html 
docs>style.css
```
