### PR TITLE
Add bottom spacing for top-level page header

### DIFF
--- a/.changeset/header-spacing.md
+++ b/.changeset/header-spacing.md
@@ -1,0 +1,7 @@
+---
+"water.css": minor
+---
+
+Add spacing and a separator for the top-level page header (`body > header`) to visually separate it from the main content. Mirrors the existing treatment for the page footer and uses the existing `--border` variable.
+
+Fixes #360.

--- a/src/parts/_misc.css
+++ b/src/parts/_misc.css
@@ -139,6 +139,13 @@ dialog::backdrop {
   backdrop-filter: blur(4px);
 }
 
+/* Add separation and spacing for the top-level page header */
+body > header {
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 10px;
+  margin-bottom: 40px;
+}
+
 footer {
   border-top: 1px solid var(--border);
   padding-top: 10px;


### PR DESCRIPTION
What: Adds spacing/separator for the page header via body > header in 
src/parts/_misc.css

Why: Visually separates the header from main content; aligns with footer treatment. Fixes lack of bottom margin reported in Issue #360.

How:
border-bottom: 1px solid var(--border)
padding-bottom: 10px
margin-bottom: 40px

Scope: Scoped to top-level header only (body > header), avoids affecting dialog headers.
Fixes kognise/water.css#360

